### PR TITLE
Add hcl support

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "keywords": [
     "terraform",
     "documentation",
-    "terragrunt"
+    "terragrunt",
+    "hcl"
   ],
   "icon": "assets/icon.png",
   "galleryBanner": {
@@ -25,7 +26,8 @@
     "theme": "dark"
   },
   "activationEvents": [
-    "onLanguage:terraform"
+    "onLanguage:terraform",
+    "onLanguage:hcl"
   ],
   "main": "./out/extension.js",
   "contributes": {


### PR DESCRIPTION
## Overview

This adds `hcl` language support to activation events. This is useful for `terragrunt.hcl` files while using the [Hashicorp HCL](https://marketplace.visualstudio.com/items?itemName=HashiCorp.HCL) vscode extension.


